### PR TITLE
feat(UI): Splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,16 +7,16 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:theme="@style/AppTheme"
         android:allowBackup="true"
         android:fullBackupContent="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
         tools:targetApi="m">
-        <activity android:name=".MainActivity">
+        <activity android:name=".SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.VIEW" />
@@ -24,6 +24,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/mokil_toast/MainActivity.java
+++ b/app/src/main/java/com/example/mokil_toast/MainActivity.java
@@ -7,6 +7,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
 import android.widget.TabHost;
 import android.widget.TextView;
@@ -38,6 +40,8 @@ public class MainActivity extends AppCompatActivity {
 
     BattleData body;
 
+    Animation fadeIn;
+
     String TAG = "MainActivity";
 
     @Override
@@ -48,6 +52,8 @@ public class MainActivity extends AppCompatActivity {
         title = findViewById(R.id.tv_title);
         tabHost = findViewById(R.id.tab_host);
         battleList = findViewById(R.id.battle_list);
+
+        fadeIn = AnimationUtils.loadAnimation(getApplicationContext(), R.anim.fade_in);
 
         getWindow().setStatusBarColor(getResources().getColor(R.color.colorBackground));
 
@@ -121,6 +127,7 @@ public class MainActivity extends AppCompatActivity {
 
                     BattleListAdapter battleListAdapter = new BattleListAdapter(body);
                     battleList.setAdapter(battleListAdapter);
+                    battleList.startAnimation(fadeIn);
                 } else {
                     Toast.makeText(MainActivity.this, "로드 실패", Toast.LENGTH_SHORT).show();
                 }

--- a/app/src/main/java/com/example/mokil_toast/MainActivity.java
+++ b/app/src/main/java/com/example/mokil_toast/MainActivity.java
@@ -80,12 +80,12 @@ public class MainActivity extends AppCompatActivity {
 
                 // Battle tab
                 if (tabIndex == 0) {
-                    title.setText(R.string.text_battle);
+                    title.setText(R.string.text_main_battle);
                 }
 
                 // Class tab
                 if (tabIndex == 1) {
-                    title.setText(R.string.text_class);
+                    title.setText(R.string.text_main_class);
                 }
             }
         });

--- a/app/src/main/java/com/example/mokil_toast/SplashActivity.java
+++ b/app/src/main/java/com/example/mokil_toast/SplashActivity.java
@@ -1,0 +1,34 @@
+package com.example.mokil_toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+
+public class SplashActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_splash);
+
+        getWindow().setStatusBarColor(getResources().getColor(R.color.colorBackground));
+
+        Handler hd = new Handler();
+        hd.postDelayed(new SplashHandler(), 1000);
+    }
+
+    @Override
+    public void onBackPressed() { }
+
+    private class SplashHandler implements Runnable {
+        @Override
+        public void run() {
+            final Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+            startActivity(intent);
+            overridePendingTransition(0, R.anim.fade_out);
+            SplashActivity.this.finish();
+        }
+    }
+}

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="500"
+    android:fromAlpha="0"
+    android:toAlpha="1">
+</alpha>

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="200"
+    android:fromAlpha="1"
+    android:toAlpha="0">
+</alpha>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
                 style="@style/titleTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/text_battle" />
+                android:text="@string/text_main_battle" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorBackground"
+    tools:context=".SplashActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/nanum_square_round_extra_bold"
+        android:text="@string/text_splash_title"
+        android:textColor="@color/colorWhite"
+        android:textSize="50sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,13 @@
 <resources>
     <string name="app_name">토스트</string>
 
+    <!-- activity_splash -->
+    <string name="text_splash_title">Toast</string>
+
     <!-- activity_main -->
-    <string name="text_battle">경기</string>
-    <string name="text_class">반</string>
-    
+    <string name="text_main_battle">경기</string>
+    <string name="text_main_class">반</string>
+
     <!-- battle_list_item -->
     <string name="sample_score1">3</string>
     <string name="sample_score2">11</string>


### PR DESCRIPTION
### 스플래시 스크린을 만들었음.
스플래시가 나오고 메인 화면이 나올 때 디졸브 효과를 넣었고, 바로 뒤에 뜨는 경기 리스트에도 역시 디졸브 효과를 넣어 자연스럽게 표시될 수 있도록 하였음.

closes: #2

> activity_splash
>
> ![Screenshot_1575238406](https://user-images.githubusercontent.com/48079406/69921181-3f3f7600-14d3-11ea-90ef-54a4e1cf20bc.png)
